### PR TITLE
Added the EmptyLineAfterInclude rule

### DIFF
--- a/ModularDocs/EmptyLineAfterInclude.yml
+++ b/ModularDocs/EmptyLineAfterInclude.yml
@@ -1,0 +1,52 @@
+# Verify that each include directive is followed by an empty line.
+---
+extends: script
+message: "Add an empty line after the include directive."
+level: warning
+scope: raw
+script: |
+  text             := import("text")
+  matches          := []
+
+  r_comment_line   := text.re_compile("^(//|//[^/].*)$")
+  r_comment_block  := text.re_compile("^/{4,}\\s*$")
+  r_include        := text.re_compile("^include::[^\\s\\[]+\\[[^\\[]*\\]\\s*$")
+
+  document         := text.split(text.trim_suffix(scope, "\n"), "\n")
+  in_comment_block := false
+  need_empty_line  := false
+  start            := 0
+  end              := 0
+
+  for line in document {
+    start += end
+    end   = len(line) + 1
+
+    if r_comment_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_comment_block {
+        in_comment_block = delimiter
+      } else if in_comment_block == delimiter {
+        in_comment_block = false
+      }
+      continue
+    }
+    if in_comment_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_include.match(line) {
+      if need_empty_line {
+        matches = append(matches, need_empty_line)
+      }
+      need_empty_line = {begin: start, end: start + end - 1}
+    } else if need_empty_line {
+      if text.trim_space(line) != "" {
+        matches = append(matches, need_empty_line)
+      }
+      need_empty_line = false
+    }
+  }
+
+  if need_empty_line {
+    matches = append(matches, need_empty_line)
+  }

--- a/fixtures/EmptyLineAfterInclude/ignore_comment_blocks.adoc
+++ b/fixtures/EmptyLineAfterInclude/ignore_comment_blocks.adoc
@@ -1,0 +1,6 @@
+////
+Include directives in a comment block:
+
+include::attributes.adoc[]
+include::appendix.adoc[]
+////

--- a/fixtures/EmptyLineAfterInclude/ignore_comment_lines.adoc
+++ b/fixtures/EmptyLineAfterInclude/ignore_comment_lines.adoc
@@ -1,0 +1,3 @@
+// Include directives in single-line comments:
+// include::attributes.adoc[]
+// include::appendix.adoc[]

--- a/fixtures/EmptyLineAfterInclude/ignore_comments_between_includes.adoc
+++ b/fixtures/EmptyLineAfterInclude/ignore_comments_between_includes.adoc
@@ -1,0 +1,14 @@
+include::attributes.adoc[]
+// A comment line should not be recognized as an empty line.
+include::preface.adoc[]
+// A comment line should not be recognized as a non-empty line either.
+
+include::typographic_conventions.adoc[]
+////
+A comment block should not be recognized as an empty line.
+////
+include::appendix.adoc[]
+////
+A comment block should not be recognized as a non-empty line either.
+////
+

--- a/fixtures/EmptyLineAfterInclude/ignore_empty_lines_after_includes.adoc
+++ b/fixtures/EmptyLineAfterInclude/ignore_empty_lines_after_includes.adoc
@@ -1,0 +1,5 @@
+// The following include directives are correctly followed by empty lines:
+include::attributes.adoc[]
+
+include::appendix.adoc[]
+

--- a/fixtures/EmptyLineAfterInclude/ignore_escaped_includes.adoc
+++ b/fixtures/EmptyLineAfterInclude/ignore_escaped_includes.adoc
@@ -1,0 +1,3 @@
+// The following include directives are escaped:
+\include::attributes.adoc[]
+\include::appendix.adoc[]

--- a/fixtures/EmptyLineAfterInclude/report_code_blocks.adoc
+++ b/fixtures/EmptyLineAfterInclude/report_code_blocks.adoc
@@ -1,0 +1,5 @@
+// The following directive is within a code block and should be reported:
+----
+include::attributes.adoc[]
+$ ln -s ../../../assemblies/
+----

--- a/fixtures/EmptyLineAfterInclude/report_include_variations.adoc
+++ b/fixtures/EmptyLineAfterInclude/report_include_variations.adoc
@@ -1,0 +1,6 @@
+// The following are valid include directives:
+include::attributes.adoc[]
+include::attributes.adoc[leveloffset=+1]
+include::attributes.adoc[lines=1;2;5..10]
+include::../../../attributes.adoc[]
+include::{common-content}/attributes.adoc[]

--- a/fixtures/EmptyLineAfterInclude/report_includes_without_empty_lines.adoc
+++ b/fixtures/EmptyLineAfterInclude/report_includes_without_empty_lines.adoc
@@ -1,0 +1,5 @@
+// The following include directives are not followed by empty lines:
+include::attributes.adoc[]
+include::preface.adoc[]
+== Additional resources
+include::appendix.adoc[]

--- a/fixtures/EmptyLineAfterInclude/vale.ini
+++ b/fixtures/EmptyLineAfterInclude/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../
+MinAlertLevel = suggestion
+
+[*.adoc]
+ModularDocs.EmptyLineAfterInclude = YES

--- a/test/EmptyLineAfterInclude.bats
+++ b/test/EmptyLineAfterInclude.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "Ignore empty lines after include directives" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_empty_lines_after_includes.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore include directives in single-line comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comment_lines.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore include directives in comment blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comment_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore escaped include directives" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_escaped_includes.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore comments between include directives" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comments_between_includes.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "ignore_comments_between_includes.adoc:1:1:ModularDocs.EmptyLineAfterInclude:Add an empty line after the include directive." ]
+  [ "${lines[1]}" = "ignore_comments_between_includes.adoc:6:1:ModularDocs.EmptyLineAfterInclude:Add an empty line after the include directive." ]
+}
+
+@test "Report include directives not followed by empty lines" {
+  run run_vale "$BATS_TEST_FILENAME" report_includes_without_empty_lines.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "report_includes_without_empty_lines.adoc:2:1:ModularDocs.EmptyLineAfterInclude:Add an empty line after the include directive." ]
+  [ "${lines[1]}" = "report_includes_without_empty_lines.adoc:3:1:ModularDocs.EmptyLineAfterInclude:Add an empty line after the include directive." ]
+  [ "${lines[2]}" = "report_includes_without_empty_lines.adoc:5:1:ModularDocs.EmptyLineAfterInclude:Add an empty line after the include directive." ]
+}
+
+@test "Recognize include directives in code blocks" {
+  run run_vale "$BATS_TEST_FILENAME" report_code_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "report_code_blocks.adoc:3:1:ModularDocs.EmptyLineAfterInclude:Add an empty line after the include directive." ]
+}
+
+@test "Recognize common include directive variations" {
+  run run_vale "$BATS_TEST_FILENAME" report_include_variations.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "report_include_variations.adoc:2:1:ModularDocs.EmptyLineAfterInclude:Add an empty line after the include directive." ]
+  [ "${lines[1]}" = "report_include_variations.adoc:3:1:ModularDocs.EmptyLineAfterInclude:Add an empty line after the include directive." ]
+  [ "${lines[2]}" = "report_include_variations.adoc:4:1:ModularDocs.EmptyLineAfterInclude:Add an empty line after the include directive." ]
+  [ "${lines[3]}" = "report_include_variations.adoc:5:1:ModularDocs.EmptyLineAfterInclude:Add an empty line after the include directive." ]
+  [ "${lines[4]}" = "report_include_variations.adoc:6:1:ModularDocs.EmptyLineAfterInclude:Add an empty line after the include directive." ]
+}


### PR DESCRIPTION
This is a recommended practice to prevent unexpected formatting errors and is [documented within the assembly template](https://github.com/redhat-documentation/modular-docs/blob/800f417a323234e3db3f57b4b3b571f46535c65e/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc?plain=1#L64).