### PR TITLE
Added the ContextDefinition rule

### DIFF
--- a/ModularDocs/ContextDefinition.yml
+++ b/ModularDocs/ContextDefinition.yml
@@ -1,0 +1,72 @@
+# Verify that if an include directive is present, the context attribute is
+# defined and its prevous value is retained and restored.
+---
+extends: script
+message: "Define :context: to enable module reuse."
+level: warning
+scope: raw
+script: |
+  text                := import("text")
+  matches             := []
+
+  r_comment_line      := text.re_compile("^(//|//[^/].*)$")
+  r_delimited_block   := text.re_compile("^(\\.{4,}|-{4,}|/{4,})\\s*$")
+  r_include_directive := text.re_compile("^include::[^\\s\\[]+" +
+    "\\[[^\\[]*\\]\\s*$")
+  r_context_defined   := text.re_compile("^:context:\\s+\\S")
+  r_context_stored    := text.re_compile("^ifdef::context\\[" +
+    ":parent-context[^!:\\s]*:\\s+\\{context\\}\\]\\s*$")
+  r_context_restored  := text.re_compile("^ifdef::parent-context" +
+    "[^\\[\\s]*\\[:context:\\s+\\{parent-context[^\\}\\s]*\\}\\]\\s*$")
+
+  in_delimited_block  := false
+  is_include_present  := false
+  is_context_defined  := false
+  is_context_stored   := false
+  is_context_restored := false
+  start               := 0
+  end                 := 0
+
+  for line in text.split(scope, "\n") {
+    start += end
+    end   = len(line) + 1
+
+    if r_delimited_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_delimited_block {
+        in_delimited_block = delimiter
+      } else if in_delimited_block == delimiter {
+        in_delimited_block = false
+      }
+      continue
+    }
+    if in_delimited_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if ! is_include_present && r_include_directive.match(line) {
+      is_include_present = {begin: start, end: start + end - 1,
+        message: "Define :context: to enable module reuse."}
+    } else if ! is_context_defined && r_context_defined.match(line) {
+      is_context_defined = {begin: start, end: start + end - 1,
+        message: "Store inherited context in :parent-context: " +
+                 "before assigning a new value."}
+    } else if ! is_context_stored && r_context_stored.match(line) {
+      is_context_stored  = {begin: start, end: start + end - 1,
+        message: "Restore inherited context from :parent-context: " +
+                 "at the end of the file."}
+    } else if ! is_context_restored && r_context_restored.match(line) {
+      is_context_restored = true
+    }
+  }
+
+  if is_include_present && ! is_context_defined {
+    matches = append(matches, is_include_present)
+  }
+
+  if is_context_defined && ! is_context_stored {
+    matches = append(matches, is_context_defined)
+  }
+
+  if is_context_stored && ! is_context_restored {
+    matches = append(matches, is_context_stored)
+  }

--- a/ModularDocs/ContextDefinition.yml
+++ b/ModularDocs/ContextDefinition.yml
@@ -40,13 +40,17 @@ script: |
       }
       continue
     }
-    if in_delimited_block { continue }
-    if r_comment_line.match(line) { continue }
 
     if ! is_include_present && r_include_directive.match(line) {
       is_include_present = {begin: start, end: start + end - 1,
         message: "Define :context: to enable module reuse."}
-    } else if ! is_context_defined && r_context_defined.match(line) {
+      continue
+    }
+
+    if in_delimited_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if ! is_context_defined && r_context_defined.match(line) {
       is_context_defined = {begin: start, end: start + end - 1,
         message: "Store inherited context in :parent-context: " +
                  "before assigning a new value."}

--- a/fixtures/ContextDefinition/ignore_code_blocks.adoc
+++ b/fixtures/ContextDefinition/ignore_code_blocks.adoc
@@ -1,0 +1,13 @@
+// Attribute definitions in code blocks:
+----
+ifdef::context[:parent-context: {context}]
+
+:context: test-module
+----
+
+include::appendix.adoc[]
+
+----
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]
+----

--- a/fixtures/ContextDefinition/ignore_comment_blocks.adoc
+++ b/fixtures/ContextDefinition/ignore_comment_blocks.adoc
@@ -1,0 +1,14 @@
+////
+Attribute definitions in comment blocks:
+
+ifdef::context[:parent-context: {context}]
+
+:context: test-module
+////
+
+include::appendix.adoc[]
+
+////
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]
+////

--- a/fixtures/ContextDefinition/ignore_comment_lines.adoc
+++ b/fixtures/ContextDefinition/ignore_comment_lines.adoc
@@ -1,0 +1,9 @@
+// Attribute definitions in single-line comments:
+//ifdef::context[:parent-context: {context}]
+
+//:context: test-module
+
+include::appendix.adoc[]
+
+//ifdef::parent-context[:context: {parent-context}]
+//ifndef::parent-context[:!context:]

--- a/fixtures/ContextDefinition/ignore_escaped_conditionals.adoc
+++ b/fixtures/ContextDefinition/ignore_escaped_conditionals.adoc
@@ -1,0 +1,9 @@
+// The following conditional directives are escaped:
+\ifdef::context[:parent-context: {context}]
+
+:context: test-module
+
+include:appendix.adoc[]
+
+\ifdef::parent-context[:context: {parent-context}]
+\ifndef::parent-context[:!context:]

--- a/fixtures/ContextDefinition/ignore_escaped_includes.adoc
+++ b/fixtures/ContextDefinition/ignore_escaped_includes.adoc
@@ -1,0 +1,2 @@
+// The following include directive is escaped:
+\include::appendix.adoc[]

--- a/fixtures/ContextDefinition/report_code_blocks.adoc
+++ b/fixtures/ContextDefinition/report_code_blocks.adoc
@@ -1,0 +1,4 @@
+// Include directive in a code block:
+----
+include::appendix.adoc[]
+----

--- a/fixtures/ContextDefinition/report_missing_context_definition.adoc
+++ b/fixtures/ContextDefinition/report_missing_context_definition.adoc
@@ -1,0 +1,2 @@
+// Missing context definition:
+include::appendix.adoc[]

--- a/fixtures/ContextDefinition/report_missing_context_restoration.adoc
+++ b/fixtures/ContextDefinition/report_missing_context_restoration.adoc
@@ -1,0 +1,6 @@
+// Missing context restoration:
+ifdef::context[:parent-context: {context}]
+
+:context: test-module
+
+include::appendix.adoc[]

--- a/fixtures/ContextDefinition/report_missing_context_retention.adoc
+++ b/fixtures/ContextDefinition/report_missing_context_retention.adoc
@@ -1,0 +1,4 @@
+// Missing context retention:
+:context: test-module
+
+include::appendix.adoc[]

--- a/fixtures/ContextDefinition/report_parent_context_variations.adoc
+++ b/fixtures/ContextDefinition/report_parent_context_variations.adoc
@@ -1,0 +1,9 @@
+// Common parent context variation:
+ifdef::context[:parent-context-of-the-module: {context}]
+
+:context: test-module
+
+include::appendix.adoc[]
+
+ifdef::parent-context-of-the-module[:context: {parent-context-of-the-module}]
+ifndef::parent-context-of-the-module[:!context:]

--- a/fixtures/ContextDefinition/vale.ini
+++ b/fixtures/ContextDefinition/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../
+MinAlertLevel = suggestion
+
+[*.adoc]
+ModularDocs.ContextDefinition = YES

--- a/test/ContextDefinition.bats
+++ b/test/ContextDefinition.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "Ignore attribute definitions in single-line comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comment_lines.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "ignore_comment_lines.adoc:6:1:ModularDocs.ContextDefinition:Define :context: to enable module reuse." ]
+}
+
+@test "Ignore attribute definitions in comment blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comment_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "ignore_comment_blocks.adoc:9:1:ModularDocs.ContextDefinition:Define :context: to enable module reuse." ]
+}
+
+@test "Ignore attribute definitions in code blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_code_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "ignore_code_blocks.adoc:8:1:ModularDocs.ContextDefinition:Define :context: to enable module reuse." ]
+}
+
+@test "Ignore escaped conditional directives" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_escaped_conditionals.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "ignore_escaped_conditionals.adoc:4:1:ModularDocs.ContextDefinition:Store inherited context in :parent-context: before assigning a new value." ]
+}
+
+@test "Ignore escaped include directives" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_escaped_includes.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report missing context definition" {
+  run run_vale "$BATS_TEST_FILENAME" report_missing_context_definition.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "report_missing_context_definition.adoc:2:1:ModularDocs.ContextDefinition:Define :context: to enable module reuse." ]
+}
+
+@test "Report missing context retention" {
+  run run_vale "$BATS_TEST_FILENAME" report_missing_context_retention.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "report_missing_context_retention.adoc:2:1:ModularDocs.ContextDefinition:Store inherited context in :parent-context: before assigning a new value." ]
+}
+
+@test "Report missing context restoration" {
+  run run_vale "$BATS_TEST_FILENAME" report_missing_context_restoration.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "report_missing_context_restoration.adoc:2:1:ModularDocs.ContextDefinition:Restore inherited context from :parent-context: at the end of the file." ]
+}
+
+@test "Recognize include directives in code blocks" {
+  run run_vale "$BATS_TEST_FILENAME" report_code_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "report_code_blocks.adoc:3:1:ModularDocs.ContextDefinition:Define :context: to enable module reuse." ]
+}
+
+@test "Recognize parent context name variations" {
+  run run_vale "$BATS_TEST_FILENAME" report_parent_context_variations.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+


### PR DESCRIPTION
As instructed in [Modular documentation reference guide](https://redhat-documentation.github.io/modular-docs/#reusing-modules), this rule verifies that:

- If an `include` statement is present, the `context` attribute is assigned a new value.
- If the `context` attribute is assigned a new value, any previously inherited value is retained in `parent-context`.
- If the previously inherited value is retained in `parent-context`, `context` is reset to this value at the end of the file.

