### PR TITLE
Includes should be ignored in comment blocks but recognized in code blocks

### DIFF
--- a/ModularDocs/ContextDefinition.yml
+++ b/ModularDocs/ContextDefinition.yml
@@ -10,7 +10,8 @@ script: |
   matches             := []
 
   r_comment_line      := text.re_compile("^(//|//[^/].*)$")
-  r_delimited_block   := text.re_compile("^(\\.{4,}|-{4,}|/{4,})\\s*$")
+  r_comment_block     := text.re_compile("^/{4,}\\s*$")
+  r_delimited_block   := text.re_compile("^(\\.{4,}|-{4,})\\s*$")
   r_include_directive := text.re_compile("^include::[^\\s\\[]+" +
     "\\[[^\\[]*\\]\\s*$")
   r_context_defined   := text.re_compile("^:context:\\s+\\S")
@@ -31,7 +32,7 @@ script: |
     start += end
     end   = len(line) + 1
 
-    if r_delimited_block.match(line) {
+    if r_delimited_block.match(line) || r_comment_block.match(line) {
       delimiter := text.trim_space(line)
       if ! in_delimited_block {
         in_delimited_block = delimiter
@@ -40,6 +41,7 @@ script: |
       }
       continue
     }
+    if r_comment_block.match(in_delimited_block) { continue }
 
     if ! is_include_present && r_include_directive.match(line) {
       is_include_present = {begin: start, end: start + end - 1,

--- a/fixtures/ContextDefinition/ignore_commented_includes.adoc
+++ b/fixtures/ContextDefinition/ignore_commented_includes.adoc
@@ -1,0 +1,11 @@
+////
+Attribute definitions and an include directive in comment blocks:
+
+ifdef::context[:parent-context: {context}]
+
+:context: test-module
+////
+
+////
+include::appendix.adoc[]
+////

--- a/test/ContextDefinition.bats
+++ b/test/ContextDefinition.bats
@@ -32,6 +32,12 @@ load test_helper
   [ "${lines[0]}" = "" ]
 }
 
+@test "Ignore include directives in comment blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_commented_includes.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
 @test "Report missing context definition" {
   run run_vale "$BATS_TEST_FILENAME" report_missing_context_definition.adoc
   [ "$status" -eq 0 ]


### PR DESCRIPTION
In my quick fix to enable includes in code blocks last night, I accidentally exposed them in comment blocks as well.