### PR TITLE
Added the ContextUsage rule

### DIFF
--- a/ModularDocs/ContextUsage.yml
+++ b/ModularDocs/ContextUsage.yml
@@ -1,0 +1,39 @@
+# Verify that all IDs include the {context} attribute. This is to ensure
+# the module can be used in multiple assemblies within the same document.
+---
+extends: script
+message: "Use {context} in the section ID to enable module reuse."
+level: warning
+scope: raw
+script: |
+  text                := import("text")
+  matches             := []
+
+  r_comment_line      := text.re_compile("^(//|//[^/].*)$")
+  r_delimited_block   := text.re_compile("^(\\.{4,}|-{4,}|/{4,})\\s*$")
+  r_section_id        := text.re_compile("^\\[id=[\"'][^\"']+[\"']\\]\\s*$")
+
+  in_delimited_block  := false
+  start               := 0
+  end                 := 0
+
+  for line in text.split(scope, "\n") {
+    start += end
+    end    = len(line) + 1
+
+    if r_delimited_block.match(line) {
+      delimiter := text.trim_space(line)
+      if ! in_delimited_block {
+        in_delimited_block = delimiter
+      } else if in_delimited_block == delimiter {
+        in_delimited_block = false
+      }
+      continue
+    }
+    if in_delimited_block { continue }
+    if r_comment_line.match(line) { continue }
+
+    if r_section_id.match(line) && ! text.contains(line, "{context}") {
+      matches = append(matches, {begin: start, end: start + end - 1})
+    }
+  }

--- a/fixtures/ContextUsage/ignore_code_blocks.adoc
+++ b/fixtures/ContextUsage/ignore_code_blocks.adoc
@@ -1,0 +1,25 @@
+// A section ID used within a delimited listing block:
+----
+[id="section-id"]
+= Section title
+----
+
+// A section ID used within a delimited literal block:
+....
+[id="section-id"]
+= Section title
+....
+
+// A section ID used within a delimited listing block with an unusual but
+// valid delimiter:
+-------
+[id="section-id"]
+= Section title
+-------
+
+// A section ID used within a delimited literal block: with an unusual but
+// valid delimiter:
+.......
+[id="section-id"]
+= Section title
+.......

--- a/fixtures/ContextUsage/ignore_comment_blocks.adoc
+++ b/fixtures/ContextUsage/ignore_comment_blocks.adoc
@@ -1,0 +1,6 @@
+////
+A section ID used in a comment block:
+
+[id="section-id"]
+////
+= Section title

--- a/fixtures/ContextUsage/ignore_comment_lines.adoc
+++ b/fixtures/ContextUsage/ignore_comment_lines.adoc
@@ -1,0 +1,3 @@
+// A section ID used in a single-line comment:
+//[id="section-id"]
+= Section title

--- a/fixtures/ContextUsage/ignore_context_variations.adoc
+++ b/fixtures/ContextUsage/ignore_context_variations.adoc
@@ -1,0 +1,15 @@
+// A section ID with the context attribute at the end:
+[id="section-id_{context}"]
+= Section title
+
+// A section ID with the context attribute at the end:
+[id="section-id-{context}"]
+= Section title
+
+// A section ID with the context attribute at the front:
+[id="{context}_section-id"]
+= Section title
+
+// A section ID with the context attribute in the middle:
+[id="sect-{context}-section-id"]
+= Section title

--- a/fixtures/ContextUsage/report_missing_context.adoc
+++ b/fixtures/ContextUsage/report_missing_context.adoc
@@ -1,0 +1,3 @@
+// A section ID without the context attribute:
+[id="section-id"]
+= Section title

--- a/fixtures/ContextUsage/vale.ini
+++ b/fixtures/ContextUsage/vale.ini
@@ -1,0 +1,5 @@
+StylesPath = ../../
+MinAlertLevel = suggestion
+
+[*.adoc]
+ModularDocs.ContextUsage = YES

--- a/test/ContextUsage.bats
+++ b/test/ContextUsage.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "Ignore section IDs in code blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_code_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore section IDs in comment blocks" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comment_blocks.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore section IDs in single-line comments" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_comment_lines.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Ignore section IDs with the context attribute" {
+  run run_vale "$BATS_TEST_FILENAME" ignore_context_variations.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "" ]
+}
+
+@test "Report section IDs without the context attribute" {
+  run run_vale "$BATS_TEST_FILENAME" report_missing_context.adoc
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "report_missing_context.adoc:2:1:ModularDocs.ContextUsage:Use {context} in the section ID to enable module reuse." ]
+}


### PR DESCRIPTION
This is a re-implementation of one of the first rules I wrote for this project. I rewrote it as an extension of `script` to reduce the absurd number of false positives the original reported for commented lines from the template.